### PR TITLE
Adds support for Brave

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,12 @@
   "permissions": [
     "http://www.facebook.com/*", "https://www.facebook.com/*"
   ],
+  "browser_action": {
+    "default_icon": {
+      "19": "logo16.png",
+      "38": "logo48.png"
+    }
+  },
   "icons": {
      "128": "logo128.png",
      "16": "logo16.png",


### PR DESCRIPTION
I pulled this extension into Brave (https://brave.com) tonight, and was pleased to see it working right out of the box. The only modification I had to make was to add `browser_action.default_icon.{19,38}` to have the icon displayed near the address-bar.

Nice extension!