### PR TITLE
Add UserScript metadata block

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -1,3 +1,19 @@
+// ==UserScript==
+// @name         Show Facebook Computer Vision Tags
+// @namespace    https://www.github.com/ageitgey/show-facebook-computer-vision-tags
+// @description  Shows what Facebook thinks your pictures contain
+// @author       Adam Geitgey
+// @version      0.0.1
+// @license      https://raw.githubusercontent.com/ageitgey/show-facebook-computer-vision-tags/master/LICENSE
+// @icon         https://raw.githubusercontent.com/ageitgey/show-facebook-computer-vision-tags/master/logo128.png
+// @downloadURL  https://raw.githubusercontent.com/ageitgey/show-facebook-computer-vision-tags/master/facebook.js
+// @match        http://www.facebook.com/*
+// @match        https://www.facebook.com/*
+// @grant        none
+// @run-at       document-idle
+// @noframes
+// ==/UserScript==
+
 const emoji_map = {
   "1 person": "👤",
   "2 people": "👥",


### PR DESCRIPTION
I found out that `facebook.js` works good as a userscript in Greasemonkey with Firefox 50, and decided to write a proper metadata block for it. This should also be compatible with Tampermonkey (for Chrome), but I haven't tested that.