### PR TITLE
Remove unnecessary line of code

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -118,5 +118,3 @@ const observer = new MutationObserver(function(mutations) {
 const config = { attributes: true, childList: true, characterData: false }
 
 observer.observe(document.body, config);
-
-show_facebook_cv_tags();


### PR DESCRIPTION
Observer already fires once after DOM loads