### PR TITLE
Include basic fix for photos page

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -78,6 +78,7 @@ const emoji_map = {
 const show_facebook_cv_tags = function() {
   const TAG_PREFIX = "Image may contain: ";
   const images = [...document.getElementsByTagName('img')];
+  const mediaThumbs = [...document.querySelectorAll('a.uiMediaThumb')];
 
   images.forEach(function(el) {
     if (el.hasAttribute("data-prev-alt") && el.getAttribute("data-prev-alt") === el.getAttribute("alt"))
@@ -91,6 +92,35 @@ const show_facebook_cv_tags = function() {
     if (isCVTag) {
       const tags = altText.slice(TAG_PREFIX.length).split(/, | and /);
       let html = "<ul style='position:absolute;top:10px;right:10px;padding:5px;font-size:12px;line-height:1.8;background-color:rgba(0,0,0,0.7);color:#fff;border-radius:5px'>";
+
+      tags.forEach(function(tag){
+        let prefix = "∙";
+
+        if (tag in emoji_map)
+          prefix = emoji_map[tag];
+
+        html += `<li>${prefix} ${tag}</li>`;
+      });
+
+      html += "</ul>";
+
+      el.style.position = 'relative';
+      el.insertAdjacentHTML('afterend', html);
+    }
+  });
+
+  mediaThumbs.forEach(function(el) {
+    if (el.hasAttribute("data-prev-aria-label") && el.getAttribute("data-prev-aria-label") === el.getAttribute("alt"))
+      return;
+
+    el.setAttribute("data-prev-aria-label", el.attributes['aria-label'].value);
+
+    const ariaLabelText = el.attributes['aria-label'].value;
+    const isCVTag = ariaLabelText.startsWith(TAG_PREFIX);
+
+    if (isCVTag) {
+      const tags = ariaLabelText.slice(TAG_PREFIX.length).split(/, | and /);
+      let html = "<ul style='z-index: 2;position:absolute;top:10px;right:10px;padding:5px;font-size:12px;line-height:1.8;background-color:rgba(0,0,0,0.7);color:#fff;border-radius:5px'>";
 
       tags.forEach(function(tag){
         let prefix = "∙";


### PR DESCRIPTION
This is not meant to be merged as is, the coding cleanliness here is unacceptably repetitive, and there is a bug where it does not automatically call "show_facebook_cv_tags" when scrolling down, so the tags don't get put on new generated images.

This is mainly here as a proof of concept (a working implementation), with the query selector 'a.uiMediaThumb', getting the data from the aria-label attribute, and with the z-index: 2; style addition to the unordered list in order to be visible. If you want me to go ahead with this change, let me know and I'll clean it up (refactor).