### PR TITLE
Change stripes emoji from wifi symbol to barber pole

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -60,7 +60,7 @@
     "Schnee": "❄️",
     "steht": "🕴",
     "stehend": "🕴",
-    "Streifen": "📶",
+    "Streifen": "💈",
     "Anzug": "🕴",
     "Sonnenbrille": "🕶",
     "schwimmen": "🏊",

--- a/locales/en_US/messages.json
+++ b/locales/en_US/messages.json
@@ -68,7 +68,7 @@
     "smiling": "😀",
     "snow": "❄️",
     "standing": "🕴",
-    "stripes": "📶",
+    "stripes": "💈",
     "suit": "🕴",
     "sunglasses": "🕶",
     "swimming": "🏊",

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -56,7 +56,7 @@
     "sonriendo": "😀",
     "nieve": "❄️",
     "de pie": "💁",
-    "rayas": "📶",
+    "rayas": "💈",
     "traje": "👔",
     "de traje": "👔",
     "gafas de sol": "😎",


### PR DESCRIPTION
Still not an ideal emoji but carries less extraneous information than the wifi symbol.

Note that the french localization does not have a stripes entry.